### PR TITLE
Remove item ability added

### DIFF
--- a/reactive-local-storage.js
+++ b/reactive-local-storage.js
@@ -14,14 +14,20 @@ ReactiveLocalStorage = (function () {
 		deps[event.key].changed()
 	})
 
-	return function (key, val) {
+	return function (key, val, rm) {
 		if (deps[key] === undefined) {
 			deps[key] = new Tracker.Dependency()
+		}
+		
+		if (rm === true) {
+			localStorage.removeItem(key);
+			deps[key].changed();
 		}
 
 		if (val !== undefined) {
 			localStorage[key] = JSON.stringify(val)
 			deps[key].changed()
+			return
 		}
 
 		deps[key].depend()


### PR DESCRIPTION
I've introduced a new `rm` flag to the function to be able to remove items from localStorage, reactively. This means, of course, that people will have to pass in an arbitrary `val` to remove items, but I couldn't find a better way without breaking the API as it is available. I can attach a function to the prototype of this class, but wanted to know you guys' opinion.
